### PR TITLE
edit icon appears on hover of task, edit buttons display below task c…

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,14 +1,14 @@
 
 /* custom styles for default task box */
 
-.task {
+.row > .task-content > .row {
   border: 1px solid black;
   border-radius: 5px;
 }
 
 .date-container {
   text-align: center;
-
+}
 /*styling for add task button*/
 .btn-secondary {
  background-color: rgb(94, 105, 247);
@@ -16,11 +16,32 @@
  right: 20px;
 }
 
-.modal {
+/* .modal {
   display: block;
-}
+} */
 
 /*styling for the date on the tasks*/
 .modal-date {
   font-size: small;
+}
+
+
+/* styling for edit views */
+.edit-content {
+  float: right;
+  display: inline;
+}
+
+.edit-content > button {
+  display: inline-block;
+  margin: 10px;
+}
+
+.edit-icon {
+  opacity: .0;
+}
+
+/* makes icon visible on hover of task*/
+.edit-icon:hover, .task-content:hover + .edit-icon{
+  opacity: 1;
 }

--- a/task.html
+++ b/task.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="stylesheet" href="bootstrap-css/bootstrap.min.css">
-  <link rel="stylesheet" href="main.css">
+  <link rel="stylesheet" type="text/css" href="main.css">
   <title>Tsk-Tsk To-Do App</title>
 </head>
 <nav>
@@ -18,23 +18,37 @@
   <!-- <div class="add-task-button">
 
   </div> -->
-  <div class="container task level-1">
+  <!-- This is where a task div begins. It should encompass editing a task as well as the standard information. It should not include any modals at this stage -->
+  <div class="container task">
     <div class="row">
-      <div class="checkbox col-1">
-        <input type="checkbox">
-      </div>
-      <div class="to-do-name col-9">
-        <p class="align-base">Laundry</p>
-      </div>
-      <div class="task-date col-2">
-        <div class="date-container">
-          <p class="month">Sept</p>
-          <p class="day">24</p>
+      <div class = "col-10 task-content level-1">
+        <div class = "row">
+          <div class="col-1 checkbox">
+            <input type="checkbox">
+          </div>
+          <div class="col-9 task-name">
+            <p class="align-base">Laundry</p>
+          </div>
+          <div class="col-2 task-date">
+            <div class="date-container">
+              <p class="month">Sept</p>
+              <p class="day">24</p>
+            </div>
+          </div>
+          <!-- edit buttons, will collapse and expand on click of edit-icon class below, but cannot code that until js is on the table -->
+          <div class= "col-12">
+            <div class = "edit-content">
+              <button type="button" class="btn done-editing">Done</button>
+              <button type="button" class="btn delete-task-button">Delete</button>
+            </div>
+          </div>
         </div>
       </div>
+      <div class = "col-1 edit-icon">
+        <img src= "https://via.placeholder.com/50x50">
+      </div>
     </div>
-
-
+  </div>
   <!-- Delete modal with "show" class added to dispay on load, remove class to hide until button press. -->
   <div class="modal fade" tabindex="-1" role="dialog" id="delete-modal-1" aria-labelledby="delete-modal-label" aria-hidden="true">
     <div class="modal-dialog" role="document">
@@ -58,9 +72,7 @@
 
  <br>
 
-  <div class="add-task-button">
-    <button type="button" class="btn btn-secondary"> + ADD Task</button>
-  </div>
+
 
   <!-- Modal with "show" class added to dispay on load, remove class to hide until button press. -->
   <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">


### PR DESCRIPTION
…ontent on right side of task body. modal display rules are commented out due to class selector interference.

Restructured tasks to take up fewer cols so that icon could be displayed to right of task as part of the same row without adopting its styling. Specified difference between high level task (includes task information and enclosed edit icon) vs task-content (includes only task information, excludes edit icon) and included new row within parent task row to created a specific enough div to be able to collapse and expand edit buttons at a later date when js gets folded into project. Please let me know if you have any further questions about structure!