### PR TITLE
finished adding desc box to collapseable menu

### DIFF
--- a/main.css
+++ b/main.css
@@ -67,7 +67,10 @@
 }
 
 /* -----------custom styles for default task box -------*/
-
+/* Centering text in a column */
+.col-centered {
+    text-align: center;
+}
 /* Style for level-1 task */
 .level-1 {
   background-color: #fff;

--- a/task.html
+++ b/task.html
@@ -159,21 +159,27 @@
               <div class="align-self-center text-center days-old-count">
                 <!-- DUE DATE ID -->
                 <p class="m-0 days-old" id="tempDueDate">10 <br /> Days Old</p>
-                <!-- TASK DESCRIPTION ID -->
-                <button id="tempTaskDescription" type="button" class="btn tooltip-btn" data-toggle="tooltip" data-placement="left" title="tempDescription">...</button>
               </div>
             </div>
-            <!-- edit buttons, will collapse and expand on click of edit-icon class below, but cannot code that until js is on the table -->
-            <div class="col-12 collapse" id="edit-this-task-id-3">
+            <!-- edit buttons and description box, will collapse and expand on click of edit-icon class below, but cannot code that until js is on the table -->
+
+
+            <div class="col-8 collapse offset-1 col-centered edit-this-task-id-3">
+            <!-- TASK DESCRIPTION ID -->
+              <button id="tempTaskDescription" type="button" class="btn tooltip-btn" data-toggle="tooltip" data-placement="left" title="tempDescription">...</button>
+            </div>
+            <div class="col-3 collapse edit-this-task-id-3">
               <div class="edit-content">
                 <button type="button" class="btn edit-button" data-toggle="collapse" data-target="#edit-this-task-id-3">Done</button>
                 <button type="button" class="btn edit-button" data-toggle="modal" data-target="#delete-task-modal">Delete</button>
               </div>
             </div>
+
+
           </div>
         </div>
         <div class="col-1 edit-container edit-icon d-none d-sm-none d-md-block">
-          <img src="assets/edit.png" data-toggle="collapse" data-target="#edit-this-task-id-3">
+          <img src="assets/edit.png" data-toggle="collapse" data-target=".edit-this-task-id-3">
         </div>
       </div>
     </div>

--- a/task.html
+++ b/task.html
@@ -92,22 +92,22 @@
             <div class="col-10 my-auto">
               <p class="counter"> 24 DAYS OLD </p>
               <p class="task-name">Laundry</p>
-              <!-- Will need to be "clickable" for mobile to togle the tip, may need to be
-              conditional so that function (the ability to click) only is enabled when mobile viewing.
-              The title attribute is where the actual text for the tip goes. the elipsis is the only thing visible with no action.-->
-              <button type="button" class="btn tooltip-btn" data-toggle="tooltip" data-placement="top" title="...Task Description...">...</button>
             </div>
-            <!-- edit buttons, will collapse and expand on click of edit-icon class below, but cannot code that until js is on the table -->
-            <div class="col-12 collapse" id="edit-this-task-id-5">
-              <div class="edit-content">
-                <button type="button" class="btn edit-button" data-toggle="collapse" data-target="#edit-this-task-id-5">Done</button>
-                <button type="button" class="btn edit-button" data-toggle="modal" data-target="#delete-task-modal">Delete</button>
+              <!-- edit buttons and description box, will collapse and expand on click of edit-icon class below, but cannot code that until js is on the table -->
+              <div class="col-8 collapse offset-1 col-centered edit-this-task-id-5">
+              <!-- TASK DESCRIPTION ID -->
+                <button id="tempTaskDescription" type="button" class="btn tooltip-btn" data-toggle="tooltip" data-placement="left" title="tempDescription">...</button>
               </div>
-            </div>
+              <div class="col-3 collapse edit-this-task-id-5">
+                <div class="edit-content">
+                  <button type="button" class="btn edit-button" data-toggle="collapse" data-target=".edit-this-task-id-5">Done</button>
+                  <button type="button" class="btn edit-button" data-toggle="modal" data-target="#delete-task-modal">Delete</button>
+                </div>
+              </div>
           </div>
         </div>
         <div class="col-1 edit-icon d-none d-sm-none d-md-block">
-          <img src="assets/edit.png" data-toggle="collapse" data-target="#edit-this-task-id-5">
+          <img src="assets/edit.png" data-toggle="collapse" data-target=".edit-this-task-id-5">
         </div>
       </div>
     </div>
@@ -123,20 +123,22 @@
             <div class="col-10 my-auto">
               <p class="counter"> 24 DAYS OLD </p>
               <p class="task-name">Laundry</p>
-              <!-- tooltip, more info on lvl 5 -->
-              <button type="button" class="btn tooltip-btn" data-toggle="tooltip" data-placement="top" title="...Task Description...">...</button>
             </div>
-            <!-- edit buttons, will collapse and expand on click of edit-icon class below, but cannot code that until js is on the table -->
-            <div class="col-12 collapse" id="edit-this-task-id-4">
-              <div class="edit-content">
-                <button type="button" class="btn edit-button" data-toggle="collapse" data-target="#edit-this-task-id-4">Done</button>
-                <button type="button" class="btn edit-button" data-toggle="modal" data-target="#delete-task-modal">Delete</button>
-              </div>
-            </div>
+                <!-- edit buttons and description box, will collapse and expand on click of edit-icon class below, but cannot code that until js is on the table -->
+                <div class="col-8 collapse offset-1 col-centered edit-this-task-id-4">
+                <!-- TASK DESCRIPTION ID -->
+                  <button id="tempTaskDescription" type="button" class="btn tooltip-btn" data-toggle="tooltip" data-placement="left" title="tempDescription">...</button>
+                </div>
+                <div class="col-3 collapse edit-this-task-id-4">
+                  <div class="edit-content">
+                    <button type="button" class="btn edit-button" data-toggle="collapse" data-target="#edit-this-task-id-4">Done</button>
+                    <button type="button" class="btn edit-button" data-toggle="modal" data-target="#delete-task-modal">Delete</button>
+                  </div>
+                </div>
           </div>
         </div>
         <div class="col-1 edit-icon d-none d-sm-none d-md-block">
-          <img src="assets/edit.png" data-toggle="collapse" data-target="#edit-this-task-id-4">
+          <img src="assets/edit.png" data-toggle="collapse" data-target=".edit-this-task-id-4">
         </div>
       </div>
     </div>
@@ -162,8 +164,6 @@
               </div>
             </div>
             <!-- edit buttons and description box, will collapse and expand on click of edit-icon class below, but cannot code that until js is on the table -->
-
-
             <div class="col-8 collapse offset-1 col-centered edit-this-task-id-3">
             <!-- TASK DESCRIPTION ID -->
               <button id="tempTaskDescription" type="button" class="btn tooltip-btn" data-toggle="tooltip" data-placement="left" title="tempDescription">...</button>
@@ -174,8 +174,6 @@
                 <button type="button" class="btn edit-button" data-toggle="modal" data-target="#delete-task-modal">Delete</button>
               </div>
             </div>
-
-
           </div>
         </div>
         <div class="col-1 edit-container edit-icon d-none d-sm-none d-md-block">


### PR DESCRIPTION
I discovered a few things about our task structure that we have been working around.

But for this ticket, I moved the description box button into a new column next to the buttons already in the collapse-able part.  Here I found out these buttons are not in their own row at all, but just an extra column that happens to move to the next line because the previous columns take up the 12 spots of the bootstrap flex box, and they are simply floated to the right.  

It works and my addition works fine as well because I had to offset it. Not sure if this will cause any problems, so I will leave that as is. If you look at the picture below it is columns on columns for days lol.  

<img width="1144" alt="screen shot 2018-10-11 at 9 47 56 am" src="https://user-images.githubusercontent.com/43282953/46816715-cb746400-cd3a-11e8-9dfa-692744c1ca27.png">

