### PR TITLE
clears add task modal forms upon submission

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -235,12 +235,17 @@ $("#add-task-modal").on("submit", function (e){
     masterTasklist.addTask(new Task(newTaskN, dueD, taskD, tempRandomID, addD));
     $("#add-task-modal").modal("hide");
     e.preventDefault();
+    clearForm();
     masterTasklist.scrollWindow(tempRandomID);
   } else {
     alert("Please Enter a Valid Task Name");
     e.preventDefault();
   }
 });
+
+function clearForm() {
+  $("#add-task-modal").find('input[type="text"]').val("");
+}
 
 // Date picker Functionality
 $( function() {

--- a/task.html
+++ b/task.html
@@ -240,7 +240,7 @@
               <h5 class="modal-title" id="add-task-modal-label">
                 <div class="form-row">
                   <div class="col-md-4">
-                    <input type="text" id="newTaskName" placeholder="...Task Name..." required>
+                    <input type="text" id="newTaskName" placeholder="Task Name" required>
                   </div>
                 </div>
               </h5>
@@ -250,11 +250,11 @@
               <!--- Task discription field------------------------------------>
               <div class="form-group">
                 <label for="form-group-input-1">Task Description</label>
-                <input type="text" class="form-control" id="newTaskDescription" placeholder="...Input Task Description...">
+                <input type="text" class="form-control" id="newTaskDescription" placeholder="Task Description">
               </div>
               <div class="form-group">
                 <label for="form-group-input-2">Due Date</label>
-                <input type="text" class="form-control newDueDate"  readonly placeholder="...Leave Blank If No Due Date...">
+                <input type="text" class="form-control newDueDate"  readonly placeholder="Due Date - Leave blank if no due date">
               </div>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
Small addition here to reset/clear add task modal fields upon submission so that when we try to add another task we can start with a fresh form and not always have a due date. 